### PR TITLE
fix incompatibility with mining drones

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -14,13 +14,16 @@ function EntityDamaged(event)
             -- and it doesn't die
             if final_health > 0 then
                 -- and its name doesn't contain ab-enraged
-                if not string.find(name, "ab%-enraged") then
-                    -- replace it with the enraged version of it.
-                    local direction = entity.direction
                     local enragedName = "ab-enraged-" .. name
-                    entity.destroy()
-                    local enragedEntity = surface.create_entity({name = enragedName, position = position, direction = direction})
-                    enragedEntity.health = final_health
+                    -- and an enraged version of the entity exists
+                    if game.entity_prototypes[enragedName] then
+                        -- replace it with the enraged version of it.
+                        local direction = entity.direction
+                        local force = entity.force
+                        entity.destroy()
+                        local enragedEntity = surface.create_entity({name = enragedName, position = position, direction = direction, force = force})
+                        enragedEntity.health = final_health
+                    end
                 end
             end
         elseif entity.get_health_ratio() > 0.6 then


### PR DESCRIPTION
fix issue where mods that created entities that don't have enraged versions, would crash the game when those entities would fall below half health

it now verifies that the enraged version of the entity actually exists

![image](https://github.com/MrNiknoc/AngryBiters/assets/2802887/f20a5493-b65b-4fa4-81ab-08312ac07c89)
